### PR TITLE
[cockpit-connectors:1.0.x] fix: avoid issue with / at the end of the URL

### DIFF
--- a/gravitee-cockpit-connectors-core/pom.xml
+++ b/gravitee-cockpit-connectors-core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.cockpit</groupId>
         <artifactId>gravitee-cockpit-connectors</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-cockpit-connectors-core</artifactId>

--- a/gravitee-cockpit-connectors-ws/pom.xml
+++ b/gravitee-cockpit-connectors-ws/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>gravitee-cockpit-connectors</artifactId>
         <groupId>io.gravitee.cockpit</groupId>
-        <version>1.0.0</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-cockpit-connectors-ws</artifactId>

--- a/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/WebSocketCockpitConnector.java
+++ b/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/WebSocketCockpitConnector.java
@@ -174,7 +174,7 @@ public class WebSocketCockpitConnector extends AbstractService<CockpitConnector>
             httpClient.webSocket(
                 webSocketEndpoint.getPort(),
                 webSocketEndpoint.getHost(),
-                webSocketEndpoint.getPath() + path,
+                webSocketEndpoint.resolvePath(path),
                 result -> {
                     if (result.succeeded()) {
                         // Re-init endpoint counter.

--- a/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/endpoints/WebSocketEndpoint.java
+++ b/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/endpoints/WebSocketEndpoint.java
@@ -31,7 +31,7 @@ public class WebSocketEndpoint {
     @Getter
     private final String url;
 
-    private URI uri;
+    private final URI uri;
 
     @Getter
     private int retryCount;
@@ -59,8 +59,8 @@ public class WebSocketEndpoint {
         return uri.getHost();
     }
 
-    public String getPath() {
-        return uri.getRawPath();
+    public String resolvePath(String path) {
+        return uri.resolve(path).getRawPath();
     }
 
     public boolean isRemovable() {

--- a/gravitee-cockpit-connectors-ws/src/test/java/io/gravitee/cockpit/connectors/ws/endpoints/WebSocketEndpointTest.java
+++ b/gravitee-cockpit-connectors-ws/src/test/java/io/gravitee/cockpit/connectors/ws/endpoints/WebSocketEndpointTest.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.cockpit.connectors.ws.endpoints;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * @author Lorie Pisicchio (lorie.pisicchio at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class WebSocketEndpointTest {
+
+    private static final String PATH = "/ws/connectors";
+
+    @ParameterizedTest
+    @ValueSource(strings = { "http://localhost:8062", "http://localhost:8062/" })
+    public void resolvePath_should_return_a_path_resolved(String baseUrl) {
+        WebSocketEndpoint endpoint = new WebSocketEndpoint(baseUrl);
+        assertThat(endpoint.resolvePath(PATH)).isEqualTo(PATH);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
         <lombok.version>1.18.12</lombok.version>
         <mockito.version>3.4.2</mockito.version>
         <junit-jupiter.version>5.5.2</junit-jupiter.version>
+        <assertj.version>3.19.0</assertj.version>
     </properties>
 
     <dependencyManagement>
@@ -110,6 +111,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-params</artifactId>
+                <version>${junit-jupiter.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-junit-jupiter</artifactId>
                 <version>${mockito.version}</version>
@@ -149,12 +156,20 @@
             <artifactId>junit-jupiter-engine</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
         </dependency>
 
         <!-- Dev dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
     <groupId>io.gravitee.cockpit</groupId>
     <artifactId>gravitee-cockpit-connectors</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Gravitee.io - Cockpit - Connectors</name>
 


### PR DESCRIPTION
Patch cockpit-connection:1.0.0 to fix the issue with trailing / in the cockpit url.