### PR TITLE
feat: handle primary/replica on connector

### DIFF
--- a/gravitee-cockpit-connectors-core/src/main/java/io/gravitee/cockpit/connectors/core/services/MonitoringCollectorService.java
+++ b/gravitee-cockpit-connectors-core/src/main/java/io/gravitee/cockpit/connectors/core/services/MonitoringCollectorService.java
@@ -92,6 +92,11 @@ public class MonitoringCollectorService implements InitializingBean {
             return;
         }
 
+        if (!cockpitConnector.isPrimary()) {
+            log.debug("Cockpit connector is not primary. Skip monitoring propagation.");
+            return;
+        }
+
         long nextLastRefreshAt = System.currentTimeMillis();
 
         log.debug("Collecting and sending monitoring data to Cockpit");

--- a/gravitee-cockpit-connectors-core/src/test/java/io/gravitee/cockpit/connectors/core/services/MonitoringCollectorServiceTest.java
+++ b/gravitee-cockpit-connectors-core/src/test/java/io/gravitee/cockpit/connectors/core/services/MonitoringCollectorServiceTest.java
@@ -33,7 +33,6 @@ import io.gravitee.node.api.healthcheck.Result;
 import io.gravitee.node.api.infos.NodeInfos;
 import io.gravitee.node.api.infos.NodeStatus;
 import io.gravitee.node.api.infos.PluginInfos;
-import io.gravitee.node.api.monitor.JvmInfo;
 import io.gravitee.node.api.monitor.Monitor;
 import io.gravitee.node.monitoring.NodeMonitoringService;
 import io.reactivex.Flowable;
@@ -70,6 +69,8 @@ class MonitoringCollectorServiceTest {
 
     @BeforeEach
     public void initMocks() {
+        lenient().when(cockpitConnector.isPrimary()).thenReturn(true);
+
         cut = new MonitoringCollectorService(nodeMonitoringService, cockpitConnector, taskScheduler, objectMapper);
         cut.ready = true;
     }
@@ -79,6 +80,14 @@ class MonitoringCollectorServiceTest {
         cut.ready = false;
         cut.collectAndSend();
         verifyNoInteractions(objectMapper, nodeMonitoringService, cockpitConnector);
+    }
+
+    @Test
+    public void collectAndSend_notPrimary() {
+        when(cockpitConnector.isPrimary()).thenReturn(false);
+
+        cut.collectAndSend();
+        verifyNoInteractions(objectMapper, nodeMonitoringService);
     }
 
     @Test

--- a/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/channel/ClientChannelEventHandler.java
+++ b/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/channel/ClientChannelEventHandler.java
@@ -15,6 +15,6 @@
  */
 package io.gravitee.cockpit.connectors.ws.channel;
 
-public interface ClientChannelCloseHandler {
+public interface ClientChannelEventHandler {
     void handle();
 }

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <spring.version>5.2.7.RELEASE</spring.version>
         <gravitee-node.version>1.12.0</gravitee-node.version>
         <gravitee-plugin.version>1.16.0</gravitee-plugin.version>
-        <gravitee-cockpit-api.version>1.5.0</gravitee-cockpit-api.version>
+        <gravitee-cockpit-api.version>1.6.0-SNAPSHOT</gravitee-cockpit-api.version>
         <lombok.version>1.18.12</lombok.version>
         <mockito.version>3.4.2</mockito.version>
         <junit-jupiter.version>5.5.2</junit-jupiter.version>


### PR DESCRIPTION
Notifies listeners when Cockpit sends data to inform that the current installation instance becomes
a primary or a replica.

MonitoringCollectorService registers listeners on primary/replica to ensure only primary instance
sends monitoring data to Cockpit.

Related gravitee-io/gravitee-cockpit#335