### PR TITLE
feat: avoid closing connection on message decode exception

### DIFF
--- a/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/channel/ClientChannel.java
+++ b/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/channel/ClientChannel.java
@@ -202,8 +202,7 @@ public class ClientChannel {
                         webSocket.close((short) 400, "Bad incoming content");
                     }
                 } catch (Exception e) {
-                    log.warn(String.format("An error occurred when trying to decode incoming content [%s]. Closing Socket.", incoming), e);
-                    webSocket.close((short) 500, "Unexpected error");
+                    log.info(String.format("An error occurred when trying to decode incoming content [%s]. Ignore message.", incoming), e);
                 }
             }
         );

--- a/gravitee-cockpit-connectors-ws/src/test/java/io/gravitee/cockpit/connectors/ws/channel/ClientChannelTest.java
+++ b/gravitee-cockpit-connectors-ws/src/test/java/io/gravitee/cockpit/connectors/ws/channel/ClientChannelTest.java
@@ -123,7 +123,7 @@ class ClientChannelTest {
     public void listenDecodeException() {
         listenCaptor.getValue().handle(Buffer.buffer("reply: invalid"));
 
-        verify(webSocket).close(eq((short) 500), eq("Unexpected error"));
+        verifyNoMoreInteractions(webSocket);
     }
 
     @Test


### PR DESCRIPTION
Before this pull request, the connector was closing connection when receiving a message he is not able to decode.
We should simply ignore the message, and keep the connection open to handle compatibility in a smoother way.