### PR TITLE
feat: create trigger in ae

### DIFF
--- a/gravitee-cockpit-connectors-core/src/main/java/io/gravitee/cockpit/connectors/core/handlers/alert/AlertTriggerCommandHandler.java
+++ b/gravitee-cockpit-connectors-core/src/main/java/io/gravitee/cockpit/connectors/core/handlers/alert/AlertTriggerCommandHandler.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.cockpit.connectors.core.handlers.alert;
+
+import io.gravitee.alert.api.trigger.Trigger;
+import io.gravitee.alert.api.trigger.TriggerProvider;
+import io.gravitee.cockpit.api.command.Command;
+import io.gravitee.cockpit.api.command.CommandHandler;
+import io.gravitee.cockpit.api.command.CommandStatus;
+import io.gravitee.cockpit.api.command.alert.trigger.create.AlertTriggerCommand;
+import io.gravitee.cockpit.api.command.alert.trigger.create.AlertTriggerReply;
+import io.reactivex.Single;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class AlertTriggerCommandHandler implements CommandHandler<AlertTriggerCommand, AlertTriggerReply> {
+
+    private final TriggerProvider triggerProvider;
+
+    public AlertTriggerCommandHandler(TriggerProvider triggerProvider) {
+        this.triggerProvider = triggerProvider;
+    }
+
+    @Override
+    public Command.Type handleType() {
+        return Command.Type.ALERT_TRIGGER_COMMAND;
+    }
+
+    @Override
+    public Single<AlertTriggerReply> handle(AlertTriggerCommand command) {
+        log.debug("Alert trigger command [{}] has been received.", command.getId());
+
+        return registerAETrigger(command.getPayload().getTrigger())
+            .map(registered -> new AlertTriggerReply(command.getId(), CommandStatus.SUCCEEDED))
+            .onErrorResumeNext(throwable -> Single.just(new AlertTriggerReply(command.getId(), CommandStatus.ERROR)));
+    }
+
+    private Single<Trigger> registerAETrigger(Trigger trigger) {
+        return Single.defer(
+            () -> {
+                triggerProvider.register(trigger);
+                log.debug("Alert trigger [{}] has been pushed to alert system.", trigger.getId());
+                return Single.just(trigger);
+            }
+        );
+    }
+}

--- a/gravitee-cockpit-connectors-core/src/main/java/io/gravitee/cockpit/connectors/core/spring/CommandHandlersConfiguration.java
+++ b/gravitee-cockpit-connectors-core/src/main/java/io/gravitee/cockpit/connectors/core/spring/CommandHandlersConfiguration.java
@@ -19,17 +19,17 @@ import io.gravitee.cockpit.api.command.Command;
 import io.gravitee.cockpit.api.command.CommandHandler;
 import io.gravitee.cockpit.api.command.Reply;
 import io.gravitee.cockpit.connectors.core.internal.CommandHandlerWrapper;
-import io.gravitee.node.api.infos.PluginInfos;
-import io.gravitee.plugin.core.api.PluginRegistry;
 import java.util.HashMap;
 import java.util.Map;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
+@ComponentScan("io.gravitee.cockpit.connectors.core.handlers")
 public class CommandHandlersConfiguration {
 
     @Bean("cockpitCommandHandlers")

--- a/gravitee-cockpit-connectors-core/src/test/java/io/gravitee/cockpit/connectors/core/handlers/alert/AlertTriggerCommandHandlerTest.java
+++ b/gravitee-cockpit-connectors-core/src/test/java/io/gravitee/cockpit/connectors/core/handlers/alert/AlertTriggerCommandHandlerTest.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.cockpit.connectors.core.handlers.alert;
+
+import static io.gravitee.cockpit.api.command.CommandStatus.ERROR;
+import static io.gravitee.cockpit.api.command.CommandStatus.SUCCEEDED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import io.gravitee.alert.api.condition.StringCondition;
+import io.gravitee.alert.api.trigger.Trigger;
+import io.gravitee.alert.api.trigger.TriggerProvider;
+import io.gravitee.cockpit.api.command.alert.trigger.create.AlertTriggerCommand;
+import io.gravitee.cockpit.api.command.alert.trigger.create.AlertTriggerPayload;
+import io.gravitee.cockpit.api.command.alert.trigger.create.AlertTriggerReply;
+import io.reactivex.observers.TestObserver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AlertTriggerCommandHandlerTest {
+
+    @Mock
+    private TriggerProvider triggerProvider;
+
+    private AlertTriggerCommandHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        handler = new AlertTriggerCommandHandler(triggerProvider);
+    }
+
+    @Test
+    void handle_registers_a_trigger_using_trigger_provider() {
+        AlertTriggerCommand command = anAlertTriggerCommand();
+
+        TestObserver<AlertTriggerReply> obs = handler.handle(command).test();
+        obs.awaitTerminalEvent();
+        obs.assertComplete();
+
+        verify(triggerProvider).register(command.getPayload().getTrigger());
+    }
+
+    @Test
+    void handle_returns_succeeded_reply() {
+        AlertTriggerCommand command = anAlertTriggerCommand();
+
+        TestObserver<AlertTriggerReply> obs = handler.handle(command).test();
+        obs.awaitTerminalEvent();
+        obs.assertComplete();
+
+        obs.assertValue(
+            reply -> {
+                assertThat(reply)
+                    .extracting(AlertTriggerReply::getCommandId, AlertTriggerReply::getCommandStatus)
+                    .containsOnly(command.getId(), SUCCEEDED);
+
+                return true;
+            }
+        );
+    }
+
+    @Test
+    void handle_returns_error_reply_when_something_wrong_happens() {
+        doThrow(new RuntimeException()).when(triggerProvider).register(any());
+
+        AlertTriggerCommand command = anAlertTriggerCommand();
+
+        TestObserver<AlertTriggerReply> obs = handler.handle(command).test();
+        obs.awaitTerminalEvent();
+        obs.assertComplete();
+
+        obs.assertValue(
+            reply -> {
+                assertThat(reply)
+                    .extracting(AlertTriggerReply::getCommandId, AlertTriggerReply::getCommandStatus)
+                    .containsOnly(command.getId(), ERROR);
+
+                return true;
+            }
+        );
+    }
+
+    private AlertTriggerCommand anAlertTriggerCommand() {
+        var trigger = Trigger
+            .on("a source")
+            .id("trigger#id")
+            .name("a trigger")
+            .condition(StringCondition.matches("node.event", "NODE_STOP", false).build())
+            .build();
+
+        var payload = new AlertTriggerPayload();
+        payload.setTrigger(trigger);
+
+        var command = new AlertTriggerCommand();
+        command.setPayload(payload);
+
+        return command;
+    }
+}

--- a/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/spring/WebSocketConnectorConfiguration.java
+++ b/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/spring/WebSocketConnectorConfiguration.java
@@ -64,6 +64,7 @@ public class WebSocketConnectorConfiguration {
     public ObjectMapper objectMapper() {
         ObjectMapper mapper = new ObjectMapper();
         mapper.disable(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES);
+        mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         return mapper;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <spring.version>5.2.7.RELEASE</spring.version>
         <gravitee-node.version>1.15.1</gravitee-node.version>
         <gravitee-plugin.version>1.16.0</gravitee-plugin.version>
+        <gravitee-alert-api.version>1.7.1</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>1.7.0-SNAPSHOT</gravitee-cockpit-api.version>
         <lombok.version>1.18.12</lombok.version>
         <mockito.version>3.4.2</mockito.version>
@@ -83,6 +84,11 @@
                 <groupId>io.gravitee.cockpit</groupId>
                 <artifactId>gravitee-cockpit-api</artifactId>
                 <version>${gravitee-cockpit-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.alert</groupId>
+                <artifactId>gravitee-alert-api</artifactId>
+                <version>${gravitee-alert-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.gravitee.plugin</groupId>


### PR DESCRIPTION
https://github.com/gravitee-io/gravitee-cockpit/issues/651

How to test?

- Need an AM EE
- Get the alert-engine connector from Artifactory (gravitee-ae-connectors-ws-1.4.0-20210720.000731-40.zip)
- Copy the connector in your GRAVITEE_HOME/plugins
- Start AM EE with the following env variables:

```
gravitee_alerts_alert-engine_enabled=true
gravitee_alerts_alert-engine_ws_discovery=true
gravitee_alerts_alert-engine_ws_endpoints_0=http://cockpit-dev-ae.cloud.gravitee.io
gravitee_alerts_alert-engine_ws_security_username=admin
gravitee_alerts_alert-engine_ws_security_password=adminadmin
```

- In Cockpit, create a trigger and check Alert Engine logs for

```
gravitee-ae-engine-7bb9965766-4ngsx gravitee-ae-engine 14:05:01.019 [hz.nifty_thompson.event-2] [] INFO  c.g.a.e.a.drools.DroolsAlertEngine - Add a trigger id[b0534861-d600-4a51-9348-61d600ba5184] name[Stopped node] source[NODE_LIFECYCLE]
```