### PR TITLE
package bundle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,9 +36,11 @@ parameters:
 
 orbs:
   slack: circleci/slack@4.2.1
-  gravitee: gravitee-io/gravitee@dev:1.0.4
+  gravitee: gravitee-io/gravitee@1.0
   secrethub: secrethub/cli@1.1.0
   # secrethub: secrethub/cli@1.0.0
+
+
 
 workflows:
   version: 2.1
@@ -154,6 +156,9 @@ workflows:
           # container_gun_image_name: 'openjdk'
           # container_gun_image_tag: '11.0.3-jdk-stretch'
           container_size: 'large'
+      - gravitee/d_cockpit_connectors_package_bundle_bis:
+          requires:
+            - maven_n_git_release
 
   standalone_release_dry_run:
     when:
@@ -175,6 +180,9 @@ workflows:
           # container_gun_image_name: 'openjdk'
           # container_gun_image_tag: '11.0.3-jdk-stretch'
           container_size: 'large'
+      - gravitee/d_cockpit_connectors_package_bundle_bis:
+          requires:
+            - maven_n_git_release
 
   standalone_nexus_staging:
     # ---
@@ -255,6 +263,9 @@ workflows:
           # container_gun_image_name: 'openjdk'
           # container_gun_image_tag: '11.0.3-jdk-stretch'
           container_size: 'large'
+      - gravitee/d_cockpit_connectors_package_bundle_bis:
+          requires:
+            - maven_n_git_release
 
   standalone_release_replay_dry_run:
     when:
@@ -277,6 +288,9 @@ workflows:
           # container_gun_image_name: 'openjdk'
           # container_gun_image_tag: '11.0.3-jdk-stretch'
           container_size: 'large'
+      - gravitee/d_cockpit_connectors_package_bundle_bis:
+          requires:
+            - maven_n_git_release
 
   standalone_nexus_staging_replay:
     # ---


### PR DESCRIPTION
Ci-dessous le lien vers la Pipeline de la standalone_release_replay en mode dry run, avec le job qui fait le package bundle, et dépose les fichiers zip de la version 2.0.0 dans le gravitee.download 

* test no. 1 : https://app.circleci.com/pipelines/github/gravitee-io/gravitee-cockpit-connectors/391/workflows/e1270a31-366d-48fc-8323-b673c9a1ba02
* test no. 2 : https://app.circleci.com/pipelines/github/gravitee-io/gravitee-cockpit-connectors/402/workflows/42c6eb29-f6c4-415e-be2a-454c48a50cd1

Ci-dessous le lien vers les fichiers zip deposés en mode dry-run :

 https://gravitee-dry-releases-downloads.cellar-c2.services.clever-cloud.com/index.html#graviteeio-cockpit/plugins/connectors/gravitee-connector-connectors-ws/

Ci-dessous le lien vers les fichiers zip deposés dans le gravitee.downloads : 
https://download.gravitee.io/#graviteeio-cockpit/plugins/connectors/gravitee-connector-connectors-ws/

Ci-dessous le lien vers la documentation slab :

https://gravitee.slab.com/posts/the-gravitee-cockpit-connectors-8gk9cqf9