### PR TITLE
Initialize renovate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @gravitee-io/cockpit

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,7 @@
+{
+    "extends": ["config:base"],
+    "prConcurrentLimit": 3,
+    "dependencyDashboard": true,
+    "commitMessageTopic": "{{depName}}",
+    "packageRules": []
+}


### PR DESCRIPTION
Description

Setup Renovate to keep our dependencies up to date.
Override #42 as Renovate bot automatically force push in the branch of the PR 🙃 so I can't rename the commit.