### PR TITLE
fix: change property name used to get endpoints

### DIFF
--- a/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/http/HttpClientConfiguration.java
+++ b/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/http/HttpClientConfiguration.java
@@ -94,14 +94,14 @@ public class HttpClientConfiguration {
     }
 
     private List<WebSocketEndpoint> initializeEndpoints() {
-        String key = String.format("cockpit.ws.endpoints[%s]", 0);
+        String key = String.format("cockpit_ws_endpoints_%s", 0);
         List<WebSocketEndpoint> endpoints = new ArrayList<>();
 
         while (environment.containsProperty(key)) {
             String url = environment.getProperty(key);
             endpoints.add(new WebSocketEndpoint(url));
 
-            key = String.format("cockpit.ws.endpoints[%s]", endpoints.size());
+            key = String.format("cockpit_ws_endpoints_%s", endpoints.size());
         }
 
         return endpoints;


### PR DESCRIPTION
https://github.com/gravitee-io/gravitee-node/pull/98 introduces a fix for properties loading.
Unfortunately, the fix is not enough: it will search property using their exact name whereas it should also search with alternative structure:

`cockpit.ws.endpoints[0]` should be equivalent to `cockpit_ws_endpoints_0`.
A fix will be done in gravitee-node. However, AM team would avoid upgrading gravitee-node, therefore, we provide a fix to avoid that.