### PR TITLE
fix(ci): remove SNAPSHOT from submodules

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,10 @@
 **Issue**
 
-https://github.com/gravitee-io/issues/issues/XXXXX
+https://github.com/gravitee-io/gravitee-cockpit-connectors/issues/XXXXX
 
 **Description**
 
-A small description of what you did in that PR.
+A small description of what you did in this PR.
 
 **Additional context**
 

--- a/gravitee-cockpit-connectors-core/pom.xml
+++ b/gravitee-cockpit-connectors-core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.cockpit</groupId>
         <artifactId>gravitee-cockpit-connectors</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>gravitee-cockpit-connectors-core</artifactId>

--- a/gravitee-cockpit-connectors-ws/pom.xml
+++ b/gravitee-cockpit-connectors-ws/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>gravitee-cockpit-connectors</artifactId>
         <groupId>io.gravitee.cockpit</groupId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>gravitee-cockpit-connectors-ws</artifactId>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/gravitee-cockpit-connectors/issues/127

**Description**

Remove missing `SNAPSHOT` from maven sub-modules
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.3.1-fix-release-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-connectors/2.3.1-fix-release-SNAPSHOT/gravitee-cockpit-connectors-2.3.1-fix-release-SNAPSHOT.zip)
  <!-- Version placeholder end -->
