### PR TITLE
chore: update plugin publish folder

### DIFF
--- a/gravitee-cockpit-connectors-ws/pom.xml
+++ b/gravitee-cockpit-connectors-ws/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <!-- Property used by the publication job in CI-->
-        <publish-folder-path>graviteeio-cockpit/plugins/connectors</publish-folder-path>
+        <publish-folder-path>graviteeio-apim/plugins/connectors</publish-folder-path>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
The connector should be published in the list of APIM plugins ([here](https://download.gravitee.io/#graviteeio-apim/plugins/connectors/gravitee-cockpit-connectors-ws/)), not Cockpit ([not here](https://download.gravitee.io/#graviteeio-cockpit/plugins/connectors/gravitee-cockpit-connectors-ws/))

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.3.1`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-connectors/2.3.1/gravitee-cockpit-connectors-2.3.1.zip)
  <!-- Version placeholder end -->
