### PR TITLE
ci: change the publication folder on download website

### DIFF
--- a/gravitee-cockpit-connectors-ws/pom.xml
+++ b/gravitee-cockpit-connectors-ws/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <!-- Property used by the publication job in CI-->
-        <publish-folder-path>graviteeio-apim/plugins/connectors</publish-folder-path>
+        <publish-folder-path>graviteeio-cockpit/plugins/connectors</publish-folder-path>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
**Issue**

N/A

**Description**

Change the publication folder so cockpit connectors are deployed here https://download.gravitee.io/#graviteeio-cockpit/plugins/connectors/gravitee-connector-connectors-ws/
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.3.5`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-connectors/2.3.5/gravitee-cockpit-connectors-2.3.5.zip)
  <!-- Version placeholder end -->
