### PR TITLE
feat: handle a graceful shutdown

### DIFF
--- a/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/channel/ClientChannel.java
+++ b/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/channel/ClientChannel.java
@@ -82,6 +82,10 @@ public class ClientChannel {
         return handleHello(node);
     }
 
+    public Completable close() {
+        return Completable.create(emitter -> webSocket.close().onSuccess(result -> emitter.onComplete()).onFailure(emitter::onError));
+    }
+
     public void cleanup() {
         resultEmitters.forEach((type, emitter) -> emitter.onError(new ChannelClosedException()));
         resultEmitters.clear();


### PR DESCRIPTION
**Issue**

https://graviteedevops.atlassian.net/browse/COC-117

**Description**

Gravitee platform does not allow catching the shutdown of the node to stop plugins. That's why we are using a Shutdown Hook to stop the connectors

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.6.0-shutdown-hook-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-connectors/2.6.0-shutdown-hook-SNAPSHOT/gravitee-cockpit-connectors-2.6.0-shutdown-hook-SNAPSHOT.zip)
  <!-- Version placeholder end -->
