### PR TITLE
fix: bump gravitee node version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,32 +4,32 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@2.5
+  gravitee: gravitee-io/gravitee@4.0.0
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)
 workflows:
-    setup_build:
-        when:
-            not: << pipeline.git.tag >>
-        jobs:
-            - gravitee/setup_plugin-build-config:
-                  filters:
-                      tags:
-                          ignore:
-                              - /.*/
+  setup_build:
+    when:
+      not: << pipeline.git.tag >>
+    jobs:
+      - gravitee/setup_plugin-build-config:
+          filters:
+            tags:
+              ignore:
+                - /.*/
 
-    setup_release:
-        when:
-            matches:
-                pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
-                value: << pipeline.git.tag >>
-        jobs:
-            - gravitee/setup_plugin-release-config:
-                  filters:
-                      branches:
-                          ignore:
-                              - /.*/
-                      tags:
-                          only:
-                              - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/
+  setup_release:
+    when:
+      matches:
+        pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
+        value: << pipeline.git.tag >>
+    jobs:
+      - gravitee/setup_plugin-release-config:
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only:
+                - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>21.0.0</version>
+        <version>21.0.1</version>
     </parent>
 
     <groupId>io.gravitee.cockpit</groupId>
@@ -39,15 +39,11 @@
     </modules>
 
     <properties>
-        <gravitee-bom.version>4.0.0</gravitee-bom.version>
-        <gravitee-node.version>3.0.1</gravitee-node.version>
-        <gravitee-plugin.version>1.25.0</gravitee-plugin.version>
+        <gravitee-bom.version>5.0.0</gravitee-bom.version>
+        <gravitee-node.version>3.1.0-alpha.11</gravitee-node.version>
+        <gravitee-plugin.version>2.0.0-alpha.1</gravitee-plugin.version>
         <gravitee-alert-api.version>2.0.0</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>2.0.0</gravitee-cockpit-api.version>
-        <lombok.version>1.18.26</lombok.version>
-        <mockito.version>5.1.1</mockito.version>
-        <junit-jupiter.version>5.9.2</junit-jupiter.version>
-        <assertj.version>3.24.2</assertj.version>
     </properties>
 
     <dependencyManagement>
@@ -93,44 +89,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-
-            <!-- Test dependencies -->
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-engine</artifactId>
-                <version>${junit-jupiter.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-api</artifactId>
-                <version>${junit-jupiter.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-params</artifactId>
-                <version>${junit-jupiter.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-junit-jupiter</artifactId>
-                <version>${mockito.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-core</artifactId>
-                <version>${mockito.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.assertj</groupId>
-                <artifactId>assertj-core</artifactId>
-                <version>${assertj.version}</version>
-                <scope>test</scope>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -173,7 +131,6 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>


### PR DESCRIPTION
**Description**

Due to an issue while using this connector with latest apim, gravitee-node has to be upgraded.

```
10:25:44.999 [cockpit-monitoring-collector-1] ERROR o.s.s.s.TaskUtils$LoggingErrorHandler - Unexpected error occurred in scheduled task
java.lang.IncompatibleClassChangeError: Found interface io.gravitee.node.monitoring.NodeMonitoringService, but class was expected
  at io.gravitee.cockpit.connectors.core.services.MonitoringCollectorService.collectAndSend(MonitoringCollectorService.java:103)
  at org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54)
  at org.springframework.scheduling.concurrent.ReschedulingRunnable.run(ReschedulingRunnable.java:96)
  at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
  at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
  at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(Unknown Source)
  at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
  at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
  at java.base/java.lang.Thread.run(Unknown Source)

```
**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.1-bump-gravitee-node-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-connectors/4.0.1-bump-gravitee-node-SNAPSHOT/gravitee-cockpit-connectors-4.0.1-bump-gravitee-node-SNAPSHOT.zip)
  <!-- Version placeholder end -->
