### PR TITLE
[master] Add configuration for WS max frame and message sizes

### DIFF
--- a/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/http/HttpClientConfiguration.java
+++ b/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/http/HttpClientConfiguration.java
@@ -81,6 +81,39 @@ public class HttpClientConfiguration {
     @Value("${cockpit.truststore.password:#{null}}")
     private String truststorePassword;
 
+    /**
+     * Max size of a WebSocket frame.
+     * Be careful when changing this value, it needs to be a good trade-off between:
+     * <ul>
+     *     <li>memory consumption (the bigger the value, the more memory is used)</li>
+     *     <li>performance (the smaller the value, the more CPU is used)</li>
+     *     <li>network usage (the smaller the value, the more network calls are made)</li>
+     * </ul>
+     * It also need to be aligned with the values set on the Cockpit side.
+     * <p>
+     *
+     * Default value is the same as the one in Vert.x, 65536 bytes (64KB).
+     *
+     * @see io.vertx.core.http.HttpClientOptions#maxWebSocketFrameSize
+     */
+    @Value("${cockpit.ws.maxWebSocketFrameSize:65536}")
+    private int maxWebSocketFrameSize;
+
+    /**
+     * A WebSocket messages can be composed of several WebSocket frames.
+     * This value is the maximum size of a WebSocket message.
+     * <p>
+     * It should be a multiple of {@link #maxWebSocketFrameSize}.
+     * <p>
+     * Default value is 200 x {@link #maxWebSocketFrameSize} = 13MB.
+     * It can sound big but when doing API Promotion with APIM, the payload can be huge as it includes the doc pages, images etc.
+     * It also need to be aligned with the values set on the Cockpit side.
+     *
+     * @see io.vertx.core.http.HttpClientOptions#maxWebSocketMessageSize
+     */
+    @Value("${cockpit.ws.maxWebSocketMessageSize:13107200}")
+    private int maxWebSocketMessageSize;
+
     public List<WebSocketEndpoint> getEndpoints() {
         if (endpoints == null) {
             endpoints = initializeEndpoints();

--- a/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/http/HttpClientFactory.java
+++ b/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/http/HttpClientFactory.java
@@ -109,6 +109,9 @@ public class HttpClientFactory {
             }
         }
 
+        options.setMaxWebSocketFrameSize(configuration.getMaxWebSocketFrameSize());
+        options.setMaxWebSocketMessageSize(configuration.getMaxWebSocketMessageSize());
+
         return vertx.createHttpClient(options);
     }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-2117
https://github.com/gravitee-io/issues/issues/9110

**Description**

Cherry pick of https://github.com/gravitee-io/gravitee-cockpit-connectors/pull/208 on the `master` branch

> Also, change the default value of `maxWebSocketMessageSize` to 13MB instead of 262KB.
> See https://github.com/gravitee-io/gravitee-cockpit/pull/3750 for more info about the context.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.1-COC-360-handle-big-ws-messages-master-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-connectors/4.0.1-COC-360-handle-big-ws-messages-master-SNAPSHOT/gravitee-cockpit-connectors-4.0.1-COC-360-handle-big-ws-messages-master-SNAPSHOT.zip)
  <!-- Version placeholder end -->
