### PR TITLE
coc-2174 update versions in alpha

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,10 +40,10 @@
 
     <properties>
         <gravitee-bom.version>5.0.0</gravitee-bom.version>
-        <gravitee-node.version>3.1.0-alpha.11</gravitee-node.version>
-        <gravitee-plugin.version>2.0.0-alpha.1</gravitee-plugin.version>
+        <gravitee-node.version>4.0.0</gravitee-node.version>
+        <gravitee-plugin.version>2.0.1</gravitee-plugin.version>
         <gravitee-alert-api.version>2.0.0</gravitee-alert-api.version>
-        <gravitee-cockpit-api.version>2.0.0</gravitee-cockpit-api.version>
+        <gravitee-cockpit-api.version>2.1.0</gravitee-cockpit-api.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
updated cockpit api, gravitee-node and gravitee-plugin version
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.2-coc-2174-update-versions-in-alpha-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-connectors/4.0.2-coc-2174-update-versions-in-alpha-SNAPSHOT/gravitee-cockpit-connectors-4.0.2-coc-2174-update-versions-in-alpha-SNAPSHOT.zip)
  <!-- Version placeholder end -->
