### PR TITLE
fix: Enforce the cockpitObjectMapper qualifier for Spring 6.1.x+

### DIFF
--- a/gravitee-cockpit-connectors-core/src/main/java/io/gravitee/cockpit/connectors/core/spring/MonitoringCollectorConfiguration.java
+++ b/gravitee-cockpit-connectors-core/src/main/java/io/gravitee/cockpit/connectors/core/spring/MonitoringCollectorConfiguration.java
@@ -34,7 +34,7 @@ public class MonitoringCollectorConfiguration {
     MonitoringCollectorService monitoringCollectorService(
         NodeMonitoringService nodeMonitoringService,
         CockpitConnector cockpitConnector,
-        ObjectMapper objectMapper
+        @Qualifier("cockpitObjectMapper") ObjectMapper objectMapper
     ) {
         ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
         taskScheduler.setThreadNamePrefix("cockpit-monitoring-collector-");


### PR DESCRIPTION
 Since Spring 6.1.x, LocalVariableTableParameterNameDiscoverer has been removed

 this may cause trouble during injection if ObjectMapper is known twice with different name accross the SpringContext hierarchy

 to avoid, this as the ObjectMapper is named explicitly in the Configuration bean we use it
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.3-fix-spring-qualifier-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-connectors/4.0.3-fix-spring-qualifier-SNAPSHOT/gravitee-cockpit-connectors-4.0.3-fix-spring-qualifier-SNAPSHOT.zip)
  <!-- Version placeholder end -->
