### PR TITLE
fix(chore): update gravitee dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,32 +4,32 @@ version: 2.1
 setup: true
 
 orbs:
-  gravitee: gravitee-io/gravitee@4.1.1
+    gravitee: gravitee-io/gravitee@4.1.1
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)
 workflows:
-  setup_build:
-    when:
-      not: << pipeline.git.tag >>
-    jobs:
-      - gravitee/setup_plugin-build-config:
-          filters:
-            tags:
-              ignore:
-                - /.*/
+    setup_build:
+        when:
+            not: << pipeline.git.tag >>
+        jobs:
+            - gravitee/setup_plugin-build-config:
+                  filters:
+                      tags:
+                          ignore:
+                              - /.*/
 
-  setup_release:
-    when:
-      matches:
-        pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
-        value: << pipeline.git.tag >>
-    jobs:
-      - gravitee/setup_plugin-release-config:
-          filters:
-            branches:
-              ignore:
-                - /.*/
-            tags:
-              only:
-                - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/
+    setup_release:
+        when:
+            matches:
+                pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
+                value: << pipeline.git.tag >>
+        jobs:
+            - gravitee/setup_plugin-release-config:
+                  filters:
+                      branches:
+                          ignore:
+                              - /.*/
+                      tags:
+                          only:
+                              - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,14 +1,11 @@
 {
-  "extends": [
-    "config:base",
-    "schedule:earlyMondays"
-  ],
-  "prConcurrentLimit": 3,
-  "rebaseWhen": "conflicted",
-  "packageRules": [
-    {
-      "matchDatasources": ["orb"],
-      "rangeStrategy": "replace"
-    }
-  ]
+    "extends": ["config:base", "schedule:earlyMondays"],
+    "prConcurrentLimit": 3,
+    "rebaseWhen": "conflicted",
+    "packageRules": [
+        {
+            "matchDatasources": ["orb"],
+            "rangeStrategy": "replace"
+        }
+    ]
 }

--- a/gravitee-cockpit-connectors-core/pom.xml
+++ b/gravitee-cockpit-connectors-core/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-cockpit-connectors-core/src/main/java/io/gravitee/cockpit/connectors/core/internal/CommandHandlerWrapper.java
+++ b/gravitee-cockpit-connectors-core/src/main/java/io/gravitee/cockpit/connectors/core/internal/CommandHandlerWrapper.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-cockpit-connectors-core/src/main/java/io/gravitee/cockpit/connectors/core/services/MonitoringCollectorService.java
+++ b/gravitee-cockpit-connectors-core/src/main/java/io/gravitee/cockpit/connectors/core/services/MonitoringCollectorService.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-cockpit-connectors-core/src/main/java/io/gravitee/cockpit/connectors/core/spring/CommandHandlersConfiguration.java
+++ b/gravitee-cockpit-connectors-core/src/main/java/io/gravitee/cockpit/connectors/core/spring/CommandHandlersConfiguration.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-cockpit-connectors-core/src/main/java/io/gravitee/cockpit/connectors/core/spring/MonitoringCollectorConfiguration.java
+++ b/gravitee-cockpit-connectors-core/src/main/java/io/gravitee/cockpit/connectors/core/spring/MonitoringCollectorConfiguration.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-cockpit-connectors-core/src/test/java/io/gravitee/cockpit/connectors/core/services/MonitoringCollectorServiceTest.java
+++ b/gravitee-cockpit-connectors-core/src/test/java/io/gravitee/cockpit/connectors/core/services/MonitoringCollectorServiceTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-cockpit-connectors-ws/pom.xml
+++ b/gravitee-cockpit-connectors-ws/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-cockpit-connectors-ws/src/main/assembly/plugin-assembly.xml
+++ b/gravitee-cockpit-connectors-ws/src/main/assembly/plugin-assembly.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/WebSocketCockpitConnector.java
+++ b/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/WebSocketCockpitConnector.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/channel/ClientChannel.java
+++ b/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/channel/ClientChannel.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/channel/ClientChannelEventHandler.java
+++ b/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/channel/ClientChannelEventHandler.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/endpoints/WebSocketEndpoint.java
+++ b/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/endpoints/WebSocketEndpoint.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/exceptions/ChannelClosedException.java
+++ b/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/exceptions/ChannelClosedException.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/http/HttpClientConfiguration.java
+++ b/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/http/HttpClientConfiguration.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/http/HttpClientFactory.java
+++ b/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/http/HttpClientFactory.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/spring/WebSocketConnectorConfiguration.java
+++ b/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/spring/WebSocketConnectorConfiguration.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-cockpit-connectors-ws/src/test/java/io/gravitee/cockpit/connectors/ws/channel/ClientChannelTest.java
+++ b/gravitee-cockpit-connectors-ws/src/test/java/io/gravitee/cockpit/connectors/ws/channel/ClientChannelTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-cockpit-connectors-ws/src/test/java/io/gravitee/cockpit/connectors/ws/endpoints/WebSocketEndpointTest.java
+++ b/gravitee-cockpit-connectors-ws/src/test/java/io/gravitee/cockpit/connectors/ws/endpoints/WebSocketEndpointTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>21.0.1</version>
+        <version>22.0.19</version>
     </parent>
 
     <groupId>io.gravitee.cockpit</groupId>
@@ -39,11 +39,13 @@
     </modules>
 
     <properties>
-        <gravitee-bom.version>5.0.0</gravitee-bom.version>
-        <gravitee-node.version>4.0.0</gravitee-node.version>
-        <gravitee-plugin.version>2.0.1</gravitee-plugin.version>
+        <gravitee-bom.version>7.0.10</gravitee-bom.version>
+        <gravitee-node.version>5.8.1</gravitee-node.version>
+        <gravitee-plugin.version>3.1.0</gravitee-plugin.version>
         <gravitee-alert-api.version>2.0.0</gravitee-alert-api.version>
-        <gravitee-cockpit-api.version>2.1.0</gravitee-cockpit-api.version>
+        <gravitee-cockpit-api.version>2.6.2</gravitee-cockpit-api.version>
+
+        <jdk.version>17</jdk.version>
     </properties>
 
     <dependencyManagement>
@@ -158,8 +160,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.12.1</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>${jdk.version}</source>
+                    <target>${jdk.version}</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
**Description**

Upgrade gravitee dependencies

The PR also adjust license declaration and code formation according to latest maven plugins' configurations

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.4-chore-upgrade-gravitee-deps-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-connectors/4.0.4-chore-upgrade-gravitee-deps-SNAPSHOT/gravitee-cockpit-connectors-4.0.4-chore-upgrade-gravitee-deps-SNAPSHOT.zip)
  <!-- Version placeholder end -->
