### PR TITLE
fix: update ExchangeSerDe interface to help Spring initialization

### DIFF
--- a/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/WebSocketCockpitConnector.java
+++ b/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/WebSocketCockpitConnector.java
@@ -16,6 +16,7 @@
 package io.gravitee.cockpit.connectors.ws;
 
 import io.gravitee.cockpit.api.CockpitConnector;
+import io.gravitee.cockpit.api.command.websocket.CockpitExchangeSerDe;
 import io.gravitee.cockpit.connectors.ws.command.CockpitConnectorCommandContext;
 import io.gravitee.common.service.AbstractService;
 import io.gravitee.exchange.api.command.Command;
@@ -45,8 +46,9 @@ import org.springframework.context.annotation.Lazy;
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
+// This class is instanciated as a Spring Component by Gravitee Node
+@SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
 @Slf4j
-@RequiredArgsConstructor
 public class WebSocketCockpitConnector extends AbstractService<CockpitConnector> implements CockpitConnector {
 
     public static final ProtocolVersion PROTOCOL_VERSION = ProtocolVersion.V1;
@@ -55,20 +57,20 @@ public class WebSocketCockpitConnector extends AbstractService<CockpitConnector>
     private Vertx vertx;
 
     @Autowired
-    private final ExchangeConnectorManager exchangeConnectorManager;
+    private ExchangeConnectorManager exchangeConnectorManager;
 
     @Autowired
     @Lazy
     @Qualifier("cockpitConnectorCommandHandlersFactory")
-    private final ConnectorCommandHandlersFactory cockpitConnectorCommandHandlersFactory;
+    private ConnectorCommandHandlersFactory cockpitConnectorCommandHandlersFactory;
 
     @Autowired
     @Qualifier("cockpitWebsocketConnectorClientFactory")
-    private final WebSocketConnectorClientFactory cockpitWebsocketConnectorClientFactory;
+    private WebSocketConnectorClientFactory cockpitWebsocketConnectorClientFactory;
 
     @Autowired
     @Qualifier("cockpitExchangeSerDe")
-    private final ExchangeSerDe cockpitExchangeSerDe;
+    private ExchangeSerDe cockpitExchangeSerDe;
 
     @Value("${cockpit.enabled:false}")
     private boolean enabled;


### PR DESCRIPTION
**Description**

Since the introduction of Integration Controller in APIM, we can see the following error

`No qualifying bean of type 'io.gravitee.exchange.api.websocket.command.ExchangeSerDe' available: expected single matching bean but found 2: cockpitExchangeSerDe,integrationExchangeSerDe`

which was due to the extra contructor which applied different bean injection.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.3-fix-cockpit-connector-init-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-connectors/5.0.3-fix-cockpit-connector-init-SNAPSHOT/gravitee-cockpit-connectors-5.0.3-fix-cockpit-connector-init-SNAPSHOT.zip)
  <!-- Version placeholder end -->
