### PR TITLE
fix: remove RequiredArgsConstructor which was overriding qualifier

### DIFF
--- a/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/WebSocketCockpitConnector.java
+++ b/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/WebSocketCockpitConnector.java
@@ -16,7 +16,6 @@
 package io.gravitee.cockpit.connectors.ws;
 
 import io.gravitee.cockpit.api.CockpitConnector;
-import io.gravitee.cockpit.api.command.websocket.CockpitExchangeSerDe;
 import io.gravitee.cockpit.connectors.ws.command.CockpitConnectorCommandContext;
 import io.gravitee.common.service.AbstractService;
 import io.gravitee.exchange.api.command.Command;
@@ -34,7 +33,6 @@ import io.gravitee.exchange.connector.websocket.client.WebSocketConnectorClientF
 import io.reactivex.rxjava3.core.Single;
 import io.vertx.rxjava3.core.Vertx;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,8 +44,6 @@ import org.springframework.context.annotation.Lazy;
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
-// This class is instanciated as a Spring Component by Gravitee Node
-@SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
 @Slf4j
 public class WebSocketCockpitConnector extends AbstractService<CockpitConnector> implements CockpitConnector {
 


### PR DESCRIPTION
**Description**

The PR attend to fix an issue when multi ExchangeSerDer are present in the spring context.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.3-fix-the-fix-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-connectors/5.0.3-fix-the-fix-SNAPSHOT/gravitee-cockpit-connectors-5.0.3-fix-the-fix-SNAPSHOT.zip)
  <!-- Version placeholder end -->
