### PR TITLE
fix(deps): bump gravitee-cockpit-api to 3.0.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,8 @@
         <gravitee-node.version>5.10.0</gravitee-node.version>
         <gravitee-plugin.version>3.1.0</gravitee-plugin.version>
         <gravitee-alert-api.version>2.0.0</gravitee-alert-api.version>
-        <gravitee-cockpit-api.version>3.0.13</gravitee-cockpit-api.version>
-        <gravitee-exchange.version>1.2.3</gravitee-exchange.version>
+        <gravitee-cockpit-api.version>3.0.18</gravitee-cockpit-api.version>
+        <gravitee-exchange.version>1.4.1</gravitee-exchange.version>
 
         <jdk.version>17</jdk.version>
     </properties>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/gravitee-cockpit-connectors/issues/XXXXX

**Description**

A small description of what you did in this PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.9-bump-gravitee-exchange-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-connectors/5.0.9-bump-gravitee-exchange-SNAPSHOT/gravitee-cockpit-connectors-5.0.9-bump-gravitee-exchange-SNAPSHOT.zip)
  <!-- Version placeholder end -->
