### PR TITLE
fix: bump exchange framework to 1.8.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,8 @@
         <gravitee-node.version>6.0.2</gravitee-node.version>
         <gravitee-plugin.version>3.1.1</gravitee-plugin.version>
         <gravitee-alert-api.version>2.0.0</gravitee-alert-api.version>
-        <gravitee-cockpit-api.version>3.0.47</gravitee-cockpit-api.version>
-        <gravitee-exchange.version>1.8.0</gravitee-exchange.version>
+        <gravitee-cockpit-api.version>3.0.49</gravitee-cockpit-api.version>
+        <gravitee-exchange.version>1.8.2</gravitee-exchange.version>
 
         <jdk.version>17</jdk.version>
     </properties>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ARCHI-391

## Description

See https://github.com/gravitee-io/gravitee-exchange/blob/main/CHANGELOG.md#182-2024-07-26
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.28-archi-391-handle-thread-blocked-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-connectors/5.0.28-archi-391-handle-thread-blocked-SNAPSHOT/gravitee-cockpit-connectors-5.0.28-archi-391-handle-thread-blocked-SNAPSHOT.zip)
  <!-- Version placeholder end -->
