### PR TITLE
chore(deps): declare gravitee-exchange-api as provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@
                 <groupId>io.gravitee.exchange</groupId>
                 <artifactId>gravitee-exchange-api</artifactId>
                 <version>${gravitee-exchange.version}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>io.gravitee.exchange</groupId>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-6226

**Description**

Let apim choose the version of gravitee-exchange-api without interference from others dependencies
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.30`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-connectors/5.0.30/gravitee-cockpit-connectors-5.0.30.zip)
  <!-- Version placeholder end -->
