### PR TITLE
fix: don’t block the starting when cockpit is not accessible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <gravitee-plugin.version>4.10.0</gravitee-plugin.version>
         <gravitee-alert-api.version>2.1.22</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>3.11.19</gravitee-cockpit-api.version>
-        <gravitee-exchange.version>1.10.0</gravitee-exchange.version>
+        <gravitee-exchange.version>2.0.1</gravitee-exchange.version>
 
         <jdk.version>17</jdk.version>
     </properties>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-8519

**Description**

This PR is a part of set ([gravitee-exchange](https://github.com/gravitee-io/gravitee-exchange/pull/89), [gravitee-cockpit-connectors](https://github.com/gravitee-io/gravitee-cockpit-connectors/pull/387) & [gravitee-api-management](https://github.com/gravitee-io/gravitee-api-management/pull/15121)) to handle the connection error to cockpit at start time.

In [gravitee-cockpit-connectors](https://github.com/gravitee-io/gravitee-cockpit-connectors/pull/387/changes#diff-f43f2130521d6a1f77297bbdb52d302ed90d299dd7f4da92ef4560a711e78286L120-R120), I make the connection async.

In all others part I handle this case to avoid NPE.

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.1.65-mba-apim-8519-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-connectors/5.1.65-mba-apim-8519-SNAPSHOT/gravitee-cockpit-connectors-5.1.65-mba-apim-8519-SNAPSHOT.zip)
  <!-- Version placeholder end -->
