### PR TITLE
feat: migrate to Vert.x 5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.16.0
+    gravitee: gravitee-io/gravitee@6.0.0
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/pom.xml
+++ b/pom.xml
@@ -39,9 +39,9 @@
     </modules>
 
     <properties>
-        <gravitee-bom.version>9.0.0-beta.2</gravitee-bom.version>
-        <gravitee-node.version>8.0.0-beta.2</gravitee-node.version>
-        <gravitee-plugin.version>4.10.0</gravitee-plugin.version>
+        <gravitee-bom.version>9.0.0-alpha.2</gravitee-bom.version>
+        <gravitee-node.version>9.0.0-alpha.1</gravitee-node.version>
+        <gravitee-plugin.version>5.0.0-alpha.3</gravitee-plugin.version>
         <gravitee-alert-api.version>2.1.22</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>4.0.0-AM-6611-vertx-5-migration-SNAPSHOT</gravitee-cockpit-api.version>
         <gravitee-exchange.version>3.0.0-AM-6611-vertx-5-migration-SNAPSHOT</gravitee-exchange.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>22.6.0</version>
+        <version>25.0.0-alpha.1</version>
     </parent>
 
     <groupId>io.gravitee.cockpit</groupId>
@@ -39,12 +39,13 @@
     </modules>
 
     <properties>
-        <gravitee-bom.version>8.3.47</gravitee-bom.version>
-        <gravitee-node.version>7.19.0</gravitee-node.version>
+        <gravitee-bom.version>9.0.0-beta.2</gravitee-bom.version>
+        <gravitee-node.version>8.0.0-beta.2</gravitee-node.version>
         <gravitee-plugin.version>4.10.0</gravitee-plugin.version>
         <gravitee-alert-api.version>2.1.22</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>3.11.19</gravitee-cockpit-api.version>
-        <gravitee-exchange.version>2.0.1</gravitee-exchange.version>
+        <gravitee-exchange.version>3.0.0-AM-6611-vertx-5-migration-SNAPSHOT</gravitee-exchange.version>
+        <gravitee.archrules.skip>true</gravitee.archrules.skip>
 
         <jdk.version>17</jdk.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <gravitee-node.version>8.0.0-beta.2</gravitee-node.version>
         <gravitee-plugin.version>4.10.0</gravitee-plugin.version>
         <gravitee-alert-api.version>2.1.22</gravitee-alert-api.version>
-        <gravitee-cockpit-api.version>3.11.19</gravitee-cockpit-api.version>
+        <gravitee-cockpit-api.version>4.0.0-AM-6611-vertx-5-migration-SNAPSHOT</gravitee-cockpit-api.version>
         <gravitee-exchange.version>3.0.0-AM-6611-vertx-5-migration-SNAPSHOT</gravitee-exchange.version>
         <gravitee.archrules.skip>true</gravitee.archrules.skip>
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/AM-6611

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.0.0-AM-6611-vertx-5-migration-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-connectors/6.0.0-AM-6611-vertx-5-migration-SNAPSHOT/gravitee-cockpit-connectors-6.0.0-AM-6611-vertx-5-migration-SNAPSHOT.zip)
  <!-- Version placeholder end -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.0.0-AM-6611-vertx-5-migration-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-connectors/6.0.0-AM-6611-vertx-5-migration-SNAPSHOT/gravitee-cockpit-connectors-6.0.0-AM-6611-vertx-5-migration-SNAPSHOT.zip)
  <!-- Version placeholder end -->
