### PR TITLE
chore: update to JDK 25 and Vert.x 5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.16.0
+    gravitee: gravitee-io/gravitee@6.0.0
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/README.md
+++ b/README.md
@@ -25,11 +25,12 @@ https://oss.sonatype.org/content/repositories/snapshots
 
 ## Compatibility matrix
 
-| Connector version | APIM Version   | AM Version     |
-|-------------------|----------------|----------------|
-| 5.1.x             | 4.6.x to upper | N/A            |
-| 5.0.x             | 4.4.x to 4.5.x | 4.4.x to upper |
-| 4.0.x             | 4.2.x to 4.3.x | 4.2.x to 4.3.x |
+| Connector version | APIM Version    | AM Version     |
+|-------------------|-----------------|----------------|
+| 6.x               | 4.12.x to upper | N/A            |
+| 5.1.x             | 4.6.x to 4.11.x | N/A            |
+| 5.0.x             | 4.4.x to 4.5.x  | 4.4.x to upper |
+| 4.0.x             | 4.2.x to 4.3.x  | 4.2.x to 4.3.x |
 
 ## Building
 
@@ -58,4 +59,3 @@ or AM installation.
 | cockpit.connector.ws.ssl.truststore.type      | PKCS12  | The truststore type (PKCS12, PEM, JKS)                                         |
 | cockpit.connector.ws.ssl.truststore.path      |         | The path to the truststore used to trust the Cockpit server                    |
 | cockpit.connector.ws.ssl.truststore.password  |         | The password to used to access the truststore information                      |
-

--- a/gravitee-cockpit-connectors-core/src/main/java/io/gravitee/cockpit/connectors/core/services/MonitoringCollectorService.java
+++ b/gravitee-cockpit-connectors-core/src/main/java/io/gravitee/cockpit/connectors/core/services/MonitoringCollectorService.java
@@ -119,8 +119,7 @@ public class MonitoringCollectorService {
     private NodeCommand convertToNodeCommand(Monitoring monitoring) throws JsonProcessingException {
         NodeInfos nodeInfos = objectMapper.readValue(monitoring.getPayload(), NodeInfos.class);
         return new NodeCommand(
-            NodeCommandPayload
-                .builder()
+            NodeCommandPayload.builder()
                 .nodeId(nodeInfos.getId())
                 .installationId(exchangeConnector.targetId())
                 .name(nodeInfos.getName())
@@ -128,7 +127,15 @@ public class MonitoringCollectorService {
                 .evaluatedAt(nodeInfos.getEvaluatedAt())
                 .status(NodeCommandPayload.Status.valueOf(nodeInfos.getStatus().name()))
                 .version(nodeInfos.getVersion())
-                .shardingTags(nodeInfos.getTags() == null ? List.of() : nodeInfos.getTags().stream().filter(tag -> !tag.isBlank()).toList())
+                .shardingTags(
+                    nodeInfos.getTags() == null
+                        ? List.of()
+                        : nodeInfos
+                            .getTags()
+                            .stream()
+                            .filter(tag -> !tag.isBlank())
+                            .toList()
+                )
                 .tenant(nodeInfos.getTenant())
                 .jdkVersion(nodeInfos.getJdkVersion())
                 .plugins(nodeInfos.getPluginInfos().stream().map(this::convertToNodePlugin).toList())
@@ -144,8 +151,7 @@ public class MonitoringCollectorService {
     private NodeHealthCheckCommand convertToHealthCheckCommand(Monitoring monitoring) throws JsonProcessingException {
         final HealthCheck healthCheck = objectMapper.readValue(monitoring.getPayload(), HealthCheck.class);
         return new NodeHealthCheckCommand(
-            NodeHealthCheckCommandPayload
-                .builder()
+            NodeHealthCheckCommandPayload.builder()
                 .nodeId(monitoring.getNodeId())
                 .installationId(exchangeConnector.targetId())
                 .evaluatedAt(healthCheck.getEvaluatedAt())
@@ -158,8 +164,7 @@ public class MonitoringCollectorService {
     private NodeHealthCheckCommandPayload.HealthCheckProbe convertToHealthCheckProbe(
         java.util.Map.Entry<String, io.gravitee.node.api.healthcheck.Result> e
     ) {
-        return NodeHealthCheckCommandPayload.HealthCheckProbe
-            .builder()
+        return NodeHealthCheckCommandPayload.HealthCheckProbe.builder()
             .key(e.getKey())
             .status(
                 e.getValue().isHealthy()

--- a/gravitee-cockpit-connectors-core/src/test/java/io/gravitee/cockpit/connectors/core/services/MonitoringCollectorServiceTest.java
+++ b/gravitee-cockpit-connectors-core/src/test/java/io/gravitee/cockpit/connectors/core/services/MonitoringCollectorServiceTest.java
@@ -142,14 +142,16 @@ class MonitoringCollectorServiceTest {
         final Monitoring nodeInfosMonitoring = new Monitoring();
         nodeInfosMonitoring.setPayload("nodeInfosPayload");
 
-        when(nodeMonitoringService.findByTypeAndTimeframe(eq(Monitoring.NODE_INFOS), anyLong(), anyLong()))
-            .thenReturn(Flowable.just(nodeInfosMonitoring));
+        when(nodeMonitoringService.findByTypeAndTimeframe(eq(Monitoring.NODE_INFOS), anyLong(), anyLong())).thenReturn(
+            Flowable.just(nodeInfosMonitoring)
+        );
 
         final Monitoring healthCheckMonitoring = new Monitoring();
         healthCheckMonitoring.setPayload("healthCheckPayload");
 
-        when(nodeMonitoringService.findByTypeAndTimeframe(eq(Monitoring.HEALTH_CHECK), anyLong(), anyLong()))
-            .thenReturn(Flowable.just(healthCheckMonitoring));
+        when(nodeMonitoringService.findByTypeAndTimeframe(eq(Monitoring.HEALTH_CHECK), anyLong(), anyLong())).thenReturn(
+            Flowable.just(healthCheckMonitoring)
+        );
 
         cut.collectAndSend();
 

--- a/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/WebSocketCockpitConnector.java
+++ b/gravitee-cockpit-connectors-ws/src/main/java/io/gravitee/cockpit/connectors/ws/WebSocketCockpitConnector.java
@@ -92,22 +92,20 @@ public class WebSocketCockpitConnector extends AbstractService<CockpitConnector>
                 integrationConnectorCommandContext,
                 PROTOCOL_VERSION
             );
-            websocketExchangeConnector =
-                new WebSocketExchangeConnector(
-                    PROTOCOL_VERSION,
-                    connectorCommandHandlers,
-                    connectorCommandAdapters,
-                    connectorReplyAdapters,
-                    vertx,
-                    cockpitWebsocketConnectorClientFactory,
-                    cockpitExchangeSerDe
-                );
+            websocketExchangeConnector = new WebSocketExchangeConnector(
+                PROTOCOL_VERSION,
+                connectorCommandHandlers,
+                connectorCommandAdapters,
+                connectorReplyAdapters,
+                vertx,
+                cockpitWebsocketConnectorClientFactory,
+                cockpitExchangeSerDe
+            );
 
             exchangeConnectorManager
                 .register(websocketExchangeConnector)
                 .andThen(
-                    Completable
-                        .fromRunnable(() -> monitoringCollectorService.start(websocketExchangeConnector))
+                    Completable.fromRunnable(() -> monitoringCollectorService.start(websocketExchangeConnector))
                         .doOnError(throwable -> log.warn("Unable to start monitoring collector for cockpit connector"))
                         .onErrorComplete()
                 )
@@ -134,13 +132,11 @@ public class WebSocketCockpitConnector extends AbstractService<CockpitConnector>
 
     @Override
     public Single<Reply<?>> sendCommand(final Command<?> command) {
-        return Single
-            .fromCallable(() -> websocketExchangeConnector.isActive())
-            .flatMap(active ->
-                active
-                    ? websocketExchangeConnector.sendCommand(command)
-                    : Single.error(new IllegalStateException("CockpitConnector is not ready yet."))
-            );
+        return Single.fromCallable(() -> websocketExchangeConnector.isActive()).flatMap(active ->
+            active
+                ? websocketExchangeConnector.sendCommand(command)
+                : Single.error(new IllegalStateException("CockpitConnector is not ready yet."))
+        );
     }
 
     private class ContainerShutdownHook extends Thread {

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>22.6.0</version>
+        <version>25.0.0-alpha.1</version>
     </parent>
 
     <groupId>io.gravitee.cockpit</groupId>
@@ -39,14 +39,12 @@
     </modules>
 
     <properties>
-        <gravitee-bom.version>8.3.47</gravitee-bom.version>
-        <gravitee-node.version>7.19.0</gravitee-node.version>
+        <gravitee-bom.version>9.0.0-alpha.2</gravitee-bom.version>
+        <gravitee-node.version>9.0.0-alpha.1</gravitee-node.version>
         <gravitee-plugin.version>4.10.0</gravitee-plugin.version>
         <gravitee-alert-api.version>2.1.22</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>3.11.19</gravitee-cockpit-api.version>
-        <gravitee-exchange.version>2.0.1</gravitee-exchange.version>
-
-        <jdk.version>17</jdk.version>
+        <gravitee-exchange.version>3.0.0-alpha.1</gravitee-exchange.version>
     </properties>
 
     <dependencyManagement>
@@ -155,51 +153,4 @@
             <optional>true</optional>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>3.4.0</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.12.0</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.5</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.15.0</version>
-                <configuration>
-                    <source>${jdk.version}</source>
-                    <target>${jdk.version}</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>com.hubspot.maven.plugins</groupId>
-                <artifactId>prettier-maven-plugin</artifactId>
-                <version>0.22</version>
-                <configuration>
-                    <nodeVersion>16.16.0</nodeVersion>
-                    <prettierJavaVersion>1.6.1</prettierJavaVersion>
-                    <skip>${skip.validation}</skip>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>


### PR DESCRIPTION
BREAKING CHANGE: Requires Java25, Vert.x 5

**Issue**

https://github.com/gravitee-io/gravitee-cockpit-connectors/issues/XXXXX

**Description**

A small description of what you did in this PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.0.0-update-gravitee-exchange-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-connectors/6.0.0-update-gravitee-exchange-SNAPSHOT/gravitee-cockpit-connectors-6.0.0-update-gravitee-exchange-SNAPSHOT.zip)
  <!-- Version placeholder end -->
