### PR TITLE
fix(deps): bump gravitee-exchange to 3.0.0-alpha.3 (CJ-4716)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <gravitee-plugin.version>5.0.0-alpha.3</gravitee-plugin.version>
         <gravitee-alert-api.version>2.1.22</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>3.12.0</gravitee-cockpit-api.version>
-        <gravitee-exchange.version>3.0.0-alpha.2</gravitee-exchange.version>
+        <gravitee-exchange.version>3.0.0-alpha.3</gravitee-exchange.version>
         <gravitee.archrules.skip>true</gravitee.archrules.skip>
 
         <jdk.version>17</jdk.version>


### PR DESCRIPTION
Bumps gravitee-exchange 3.0.0-alpha.2 → 3.0.0-alpha.3 (for APIM master and 4.12 which are on 3.0.0-alpha.2) to pick up the `;;` separator fix.

Ticket: https://gravitee.atlassian.net/browse/CJ-4716
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.0.0-chore-cj-4716-bump-exchange-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-connectors/6.0.0-chore-cj-4716-bump-exchange-SNAPSHOT/gravitee-cockpit-connectors-6.0.0-chore-cj-4716-bump-exchange-SNAPSHOT.zip)
  <!-- Version placeholder end -->
