### PR TITLE
chore(deps): bump gravitee-exchange to 2.0.2 (CJ-4716)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <gravitee-plugin.version>4.11.1</gravitee-plugin.version>
         <gravitee-alert-api.version>2.1.22</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>3.12.0</gravitee-cockpit-api.version>
-        <gravitee-exchange.version>2.0.1</gravitee-exchange.version>
+        <gravitee-exchange.version>2.0.2</gravitee-exchange.version>
 
         <jdk.version>17</jdk.version>
     </properties>


### PR DESCRIPTION
Bumps gravitee-exchange 2.0.1 → 2.0.2 to pick up the `;;` separator fix (https://github.com/gravitee-io/gravitee-exchange/pull/95)

Ticket: https://gravitee.atlassian.net/browse/CJ-4716

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.1.67`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-connectors/5.1.67/gravitee-cockpit-connectors-5.1.67.zip)
  <!-- Version placeholder end -->
